### PR TITLE
Add OPI Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -2886,3 +2886,7 @@ With [Kabootar](https://staging.kabootar.potatokitty.me/), now you can share all
 ### Rucksack
 Rucksack is a CLI tool written in Rust that can backup and maintain passwords from remote services (file store is encrypted, and sensitive records in the filestore are also encrypted). It also supports exporting files for use by services for importing. It can manage passwords, service credentials, cert files, and asymmetric crypto files (public/private keys). 
 https://github.com/oxur/rucksack
+
+### Open Programmable Infrastructure
+OPI is focused on utilizing  open software and standards, as well as frameworks and toolkits, to allow for the rapid adoption and use of DPUs/IPUs. The OPI Project is both hardware and software companies coming together to establish and nurture an ecosystem to support these solutions. It “seeks to help define the architecture and frameworks for the DPU and IPU software stacks that can be applied to any vendor’s hardware offerings. The OPI Project also aims to foster a rich open source application ecosystem, leveraging existing open source projects, such as DPDK, SPDK, OvS, P4, etc., as appropriate.”
+https://opiproject.org


### PR DESCRIPTION
## Your Project

#### 1Password Teams URL
https://opi-team.1password.com/

#### Project Name
Open Programmable Infrastructure

#### Short Description
OPI, a Linux Foundation Project" is focused on utilizing  open software and standards, as well as frameworks and toolkits, to allow for the rapid adoption and use of DPUs/IPUs. The OPI Project is both hardware and software companies coming together to establish and nurture an ecosystem to support these solutions.
#### Project Age
8 Months

#### Number Of Core Contributors
20

#### Project Website
https://opiproject.org

#### Repository URL(s)
https://github.com/opiproject

#### Latest Release URL(s)
First release will be in 2-3 months

#### License
Apache V2
https://github.com/opiproject/opi/blob/main/LICENSE 

## A Bit About Yourself
I'm Sridhar Rao, Senior Technology Architect at Linux Foundation, and the Project Manager for the OPI.

#### Name
Sridhar K. N. Rao

#### Email
1password@opiproject.org

#### Project Role
Project Manager.

#### Profile/Website
https://github.com/opensource-tnbt

#### Anything else to add?

#### Can we contact you?
We'd love to be in touch to learn how you're using 1Password. Would you be open to our Developer Advocates reaching out?

- [ YES] Yes, I'm open.
